### PR TITLE
v1.9 debugX events disabled

### DIFF
--- a/Software/Facility_Database_SW/datalogging/rfidcheckindebugactivity.php
+++ b/Software/Facility_Database_SW/datalogging/rfidcheckindebugactivity.php
@@ -1,0 +1,221 @@
+
+<?php
+
+// report from RFID LOGGING DATABASE
+//
+// checkin debug activity reports
+//
+// Creative Commons: Attribution/Share Alike/Non Commercial (cc) 2019 Maker Nexus
+// By Jim Schrempp
+
+include 'commonfunctions.php';
+
+// get the HTML skeleton
+
+$html = file_get_contents("rfidcheckindebugactivity.txt");
+if (!$html){
+  die("unable to open file");
+}
+
+// Get the data
+$ini_array = parse_ini_file("rfidconfig.ini", true);
+$dbUser = $ini_array["SQL_DB"]["readOnlyUser"];
+$dbPassword = $ini_array["SQL_DB"]["readOnlyPassword"];
+$dbName = $ini_array["SQL_DB"]["dataBaseName"];
+
+$con = mysqli_connect("localhost",$dbUser,$dbPassword,$dbName);
+
+// Check connection
+if (mysqli_connect_errno()) {
+    echo "Failed to connect to MySQL: " . mysqli_connect_error();
+  }
+
+
+// ------------ TABLE 1  
+  
+$selectSQLCheckEventsPerMonth = "
+SELECT MONTH(dateEventLocal) as mnth, YEAR(dateEventLocal) as yr, count(recNum) as cnt
+FROM `rawdata` rd
+WHERE dateEventLocal > '20191001'
+  and eventName = 'RFIDLogCheckInOut'
+group by YEAR(dateEventLocal), MONTH(dateEventLocal)
+order by YEAR(dateEventLocal), MONTH(dateEventLocal)
+";
+
+$result = mysqli_query($con, $selectSQLCheckEventsPerMonth);
+$dataX = "";
+$dataY = "";
+
+// Construct the page
+if (mysqli_num_rows($result) > 0) {
+
+	// Get the data for each month into table rows
+    while($row = mysqli_fetch_assoc($result)) {
+    	
+    	$thisTableRow = makeTR( array (
+                 $row["yr"], 
+                 $row["mnth"],
+                 $row["cnt"]
+                 )     
+           );
+      
+        if ($dataX == "") {
+            $dataX =  $row["yr"] . "/" . $row["mnth"];
+            $dataY =  $row["cnt"];
+        } else {
+            $dataX = $dataX . " " . $row["yr"] . "/" . $row["mnth"];
+            $dataY = $dataY . " " . $row["cnt"];
+        }
+    	$tableRows = $tableRows . $thisTableRow;
+    }
+    
+    $html = str_replace("<<GRAPH1DATAX>>",$dataX,$html);
+    $html = str_replace("<<GRAPH1DATAY>>",$dataY,$html);
+
+    $html = str_replace("<<TABLEHEADER_RecordsPerMonth>>",
+    	makeTR(
+    		array( 
+    			"Year",
+    			"Month",
+    			"num of RFIDLogCheckInOut"
+    			)
+    		),
+    	$html);
+    $html = str_replace("<<TABLEROWS_RecordsPerMonth>>", $tableRows,$html);
+
+} else {
+    echo "0 results";
+}
+
+
+// ------------ TABLE 2  
+
+$tableRows = "";
+
+$selectSQLLogRecordsPerDay = "
+SELECT DAYOFYEAR(dateEventLocal) as DOY, MONTH(dateEventLocal) as mnth, YEAR(dateEventLocal) as yr, count(recNum) as cnt
+FROM `rawdata` rd
+WHERE dateEventLocal > '20191001'
+group by YEAR(dateEventLocal), MONTH(dateEventLocal)
+order by YEAR(dateEventLocal), MONTH(dateEventLocal)
+";
+
+
+
+$result2 = mysqli_query($con, $selectSQLLogRecordsPerDay);
+
+// Construct the page
+$dataX = "";
+$dataY = "";
+
+if (mysqli_num_rows($result2) > 0) {
+
+	// Get the data for each day into table rows
+    while($row = mysqli_fetch_assoc($result2)) {
+    
+        $thisTableRow = makeTR( array (
+            $row["yr"], 
+            $row["mnth"],
+            $row["cnt"]
+            )     
+        );
+    
+        if ($dataX == "") {
+            $dataX =  $row["yr"] . "/" . $row["mnth"];
+            $dataY =  $row["cnt"];
+        } else {
+            $dataX = $dataX . " " . $row["yr"] . "/" . $row["mnth"];
+            $dataY = $dataY . " " . $row["cnt"];
+        }
+        $tableRows = $tableRows . $thisTableRow;
+
+        /*
+        // this code puts in a row per DOY and inserts 0's when needed
+        $thisDOY = intval($row["DOY"]);
+        
+        $thisTableRow = makeTR( array (
+                    $row["DOY"],
+                    $row["yr"], 
+                    $row["mnth"],
+                    $row["dy"],
+                    $row["cnt"]
+                    )     
+            );
+        if ($dataX == "") {
+            // first row
+            $previousDOY = $row["yr"] . "/" . $thisDOY;
+            $dataX = $thisDOY;
+            $dataY =  $row["cnt"];
+        } else {
+            while ($thisDOY > ($previousDOY + 1)) {
+                // if we have a gap in day of year, add 0 data values
+                $previousDOY = $previousDOY + 1;
+                $dataX = $dataX . " " . $row["yr"] . "/" . $previousDOY;
+                $dataY = $dataY . " 0";
+            }
+            $previousDOY = $thisDOY;
+            $dataX = $dataX . " " . $row["yr"] . "/" . $thisDOY;
+            $dataY = $dataY . " " . $row["cnt"];
+        }
+        $tableRows = $tableRows . $thisTableRow;
+        */
+    }
+    
+    $html = str_replace("<<GRAPH2DATAX>>",$dataX,$html);
+    $html = str_replace("<<GRAPH2DATAY>>",$dataY,$html);
+
+    $html = str_replace("<<TABLEHEADER_LogRecordsPerDay>>",
+    	makeTR(
+    		array( 
+                "Year",
+                "Month",
+    			"Count"
+    			)
+    		),
+    	$html);
+    $html = str_replace("<<TABLEROWS_LogRecordsPerDay>>", $tableRows,$html);
+
+} else {
+    echo "0 results";
+}
+
+/*
+// ------------- Report Data 3 ---------------
+
+$tableRows = "";
+
+$SQLDateRange = date("'Y-m-d'",strtotime("60 days ago")) . " AND " .  date("'Y-m-d'",time()) ;
+
+$selectSQLMembersLast90Days = "
+SELECT COUNT(DISTINCT rd.clientID) as numUnique
+FROM rawdata rd
+LEFT JOIN clientInfo ci
+ON rd.clientID = ci.clientID
+WHERE dateEventLocal BETWEEN "
+. $SQLDateRange .
+" and logEvent = 'Checked In'
+  and (TRIM(displayClasses) <> 'staff' OR displayClasses is NULL);
+";
+
+$result3 = mysqli_query($con, $selectSQLMembersLast90Days);
+
+if (mysqli_num_rows($result3) > 0) {
+
+    $row = mysqli_fetch_assoc($result3);
+    $html = str_replace("<<UNIQUE90>>", $row["numUnique"],$html);
+
+} else {
+    $html = str_replace("<<UNIQUE90>>", "no results found",$html);
+}
+
+*/
+
+// ------------- final output ----------
+
+echo $html;
+
+mysqli_close($con);
+
+return;
+
+?>

--- a/Software/Facility_Database_SW/datalogging/rfidcheckindebugactivity.txt
+++ b/Software/Facility_Database_SW/datalogging/rfidcheckindebugactivity.txt
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Summary Reports of log records for debug</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <link href="style.css" rel="stylesheet">
+
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+
+<body>
+	<H2>Summary of log records</H2>
+	
+	<div style="float:left;">
+		<div id='graph1'></div>
+	</div>
+
+	<div style="float:left;">
+		<div id='graph2'></div>
+	</div>
+
+	<div style="float:left;">
+		<H2>Place Holder for future report</H2>
+	</div>
+
+	<div style="float:left; clear:both">
+		<h1>Log records Event: RFIDLogCheckInOut</h1>
+		<table class="rawlogtable">
+		<<TABLEHEADER_RecordsPerMonth>>
+		<<TABLEROWS_RecordsPerMonth>>
+		</table>
+	</div>
+	
+	<div style="float:left; clear:both;">
+		<h1>Total DB Records Added</h1>
+		<table class="rawlogtable">
+		<<TABLEHEADER_LogRecordsPerDay>>
+		<<TABLEROWS_LogRecordsPerDay>>
+		</table>
+	</div>
+
+
+
+	<!-- hidden div for passing data from PHP to the JS graphing functions -->
+	<div id="graph1data" style="display:none">
+		<div id="graph1dataX"><<GRAPH1DATAX>></div><div id="graph1dataY"><<GRAPH1DATAY>></div>
+	</div>
+	<div id="graph2data" style="display:none">
+		<div id="graph2dataX"><<GRAPH2DATAX>></div><div id="graph2dataY"><<GRAPH2DATAY>></div>
+	</div>
+
+	<script>
+		dataX = document.getElementById('graph1dataX').textContent;
+		dataY = document.getElementById('graph1dataY').textContent;
+		var x = dataX.split(" ");
+		var y = dataY.split(" ").map(Number);
+		var graphdata1 = [
+			{
+				x:x, 
+				y:y, 
+				type:"bar"
+			}
+		];
+		var graphlayout1 = {
+			autosize: false,
+			width: 400,
+			height: 350,
+			title: {
+				text:'RFIDLogCheckInOut counts',
+				font: {
+				family: 'Courier New, monospace',
+				size: 16
+				},
+				xref: 'paper',
+				x: 0.05,
+			}
+		};
+
+		gdiv1 = document.getElementById('graph1');
+		Plotly.newPlot(gdiv1,graphdata1,graphlayout1,{responsive: true});
+
+
+		dataX = document.getElementById('graph2dataX').textContent;
+		dataY = document.getElementById('graph2dataY').textContent;
+		var x = dataX.split(" ");
+		var y = dataY.split(" ").map(Number);
+		var graphdata2 = [
+			{
+				x:x, 
+				y:y, 
+				type:"bar"
+			}
+		];
+		var graphlayout2 = {
+			autosize: false,
+			width: 600,
+			height: 350,
+			title: {
+				text:'Total DB Records Added',
+				font: {
+				family: 'Courier New, monospace',
+				size: 16
+				},
+				xref: 'paper',
+				x: 0.05,
+			}
+		};
+
+		gdiv2 = document.getElementById('graph2');
+		Plotly.newPlot(gdiv2,graphdata2,graphlayout2,{responsive: true});
+	</script>
+</body>
+
+</html>

--- a/Software/Facility_Database_SW/datalogging/rfidhome.html
+++ b/Software/Facility_Database_SW/datalogging/rfidhome.html
@@ -28,6 +28,10 @@
 	<a href="rfiddevicelog.php">Log by Device</a><br><br>
 	
 	<a href="rfidtop100.php">Last 100 Raw Data</a><br><br>
+
+    <a href="rfidcheckindebugactivity.php">Overall logging counts</a><br><br>
+
+    
 	
 
 </body>

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -135,8 +135,10 @@
  *  1.73 new build with PRODUCTION switch in mnutils.h
  *  1.8  ezfReceiveClientByClientID has been reworked to handle the case where the response is more than one 
  *       part from Particle Cloud and the parts come out of order.
+ *  1.9  added DEBUGX_EVENTS_ALLOWED define in mnutils.h to disable publishing debugX events in production
+ *       the checked in code should have this define commented out. Also, runs on Particle 3.0
 ************************************************************************/
-#define MN_FIRMWARE_VERSION 1.8
+#define MN_FIRMWARE_VERSION 1.9
 
 // Our UTILITIES
 #include "mnutils.h"

--- a/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
+++ b/Software/Particle_SW/stationfirmware/src/checkinfirmware.ino
@@ -901,7 +901,7 @@ void ezfReceiveClientByClientID (const char *event, const char *data)  {
         // we have gone too long, so this must be a new set of parts
         // reset all our local state
         debugEvent("clearing client info receive");
-        receiveFirstMS = millis();
+        receiveFirstMS = millis(); 
         for (int i=0; i < MAX_CLIENT_INFO_PIECES; i++){
             pieces[i] = "";
         }
@@ -1648,7 +1648,7 @@ void loopEquipStation() {
         } else {
             // timer to limit this state
             if (millis() - processStartMilliseconds > 30000) {
-                debugEvent("15 second timer exeeded for packages, aborts");
+                debugEvent("30 second timer exeeded for packages, aborts");
                 processStartMilliseconds = 0;
                 writeToLCD("Timeout packages", "Try Again");
                 buzzerBadBeep();

--- a/Software/Particle_SW/stationfirmware/src/mnutils.cpp
+++ b/Software/Particle_SW/stationfirmware/src/mnutils.cpp
@@ -120,7 +120,8 @@ int particlePublish (String eventName, String data) {
 String messageBuffer = "";
 // Call this from the main look with a null message
 void debugEvent (String message) {
-    
+
+#ifdef DEBUGX_EVENTS_ALLOWED    
     if (message.length() > 0 ){
         // a message was passed in
         
@@ -150,6 +151,8 @@ void debugEvent (String message) {
             }
         }
     }
+#endif
+
 }
 
 

--- a/Software/Particle_SW/stationfirmware/src/mnutils.h
+++ b/Software/Particle_SW/stationfirmware/src/mnutils.h
@@ -10,6 +10,9 @@
 // used in rfidkeys.cpp
 //#define MN_PRODUCTION_COMPILE 
 
+//#define DEBUGX_EVENTS_ALLOWED  //These events consume Particle cloud Data Operations and should not be enabled for
+                               //every production device for weeks at a time. 
+
 //#define TEST     // uncomment for debugging mode
 #define RFID_READER_PRESENT  // uncomment when an RFID reader is connected
 #define LCD_PRESENT  // uncomment when an LCD display is connected


### PR DESCRIPTION
1. debugX events were accounting for a lot of Particle Data Operations. These events are not disabled with a #define in mnutils.h   
2. This was tested on Particle OS 3.0 on an Argon (no changes were needed)
