### PR TITLE
v2.2 Json no wait #85

### DIFF
--- a/Software/Particle_SW/stationfirmware/src/mnutils.cpp
+++ b/Software/Particle_SW/stationfirmware/src/mnutils.cpp
@@ -232,6 +232,7 @@ void EEPROMRead() {
 void clearClientInfo() {
     
     g_clientInfo.isValid = false;
+    g_clientInfo.isError = false;
     g_clientInfo.lastName = "";
     g_clientInfo.firstName = "";
     g_clientInfo.clientID = 0;

--- a/Software/Particle_SW/stationfirmware/src/mnutils.h
+++ b/Software/Particle_SW/stationfirmware/src/mnutils.h
@@ -8,7 +8,7 @@
 
 // when defined, we are compiling for production, else development
 // used in rfidkeys.cpp
-#define MN_PRODUCTION_COMPILE 
+//#define MN_PRODUCTION_COMPILE 
 
 //#define DEBUGX_EVENTS_ALLOWED  //These events consume Particle cloud Data Operations and should not be enabled for
                                //every production device for weeks at a time. 

--- a/Software/Particle_SW/stationfirmware/src/mnutils.h
+++ b/Software/Particle_SW/stationfirmware/src/mnutils.h
@@ -8,7 +8,7 @@
 
 // when defined, we are compiling for production, else development
 // used in rfidkeys.cpp
-//#define MN_PRODUCTION_COMPILE 
+#define MN_PRODUCTION_COMPILE 
 
 //#define DEBUGX_EVENTS_ALLOWED  //These events consume Particle cloud Data Operations and should not be enabled for
                                //every production device for weeks at a time. 
@@ -89,6 +89,7 @@ struct  struct_clientInfo {  // holds info on the current client
     String lastName = "";           // lastName
     String firstName = "";      // just the first lastName
     bool isValid = false;        // when true this sturcture has good data in it
+    bool isError = false;     // when the JSON does not parse, this is set TRUE
     int clientID = 0;           // numeric value assigned by EZFacility. Guaranteed to be unique
     String RFIDCardKey = "";    // string stored in EZFacility "custom fields". We may want to change this name
     String memberNumber = "";   // string stored in EZFacility. May not be unique


### PR DESCRIPTION
This fixes enhancement #85. getClientByClientID now only allows one message back from the webhook - our mustache code in the webhook makes this possible. Now if the first message does not deserialize we give the user an error (as before) but now we also log the JSON to the FDB for analysis.